### PR TITLE
Updates and minor improvements

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,1 @@
+force_default['nodejs']['dir'] = '/usr' if node['nodejs']['install_method'] == 'package'

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name 		 "application_nodejs"
 maintainer       "Conrad Kramer"
 maintainer_email "conrad@kramerapps.com"
 license          "Apache 2.0"

--- a/providers/nodejs.rb
+++ b/providers/nodejs.rb
@@ -22,7 +22,7 @@ include Chef::DSL::IncludeRecipe
 
 action :before_compile do
 
-  include_recipe 'nodejs::install_from_source'
+  include_recipe 'nodejs'
 
   if new_resource.npm
     include_recipe 'nodejs::npm'

--- a/providers/nodejs.rb
+++ b/providers/nodejs.rb
@@ -70,6 +70,8 @@ end
 
 action :before_restart do
 
+  node_binary = ::File.join(node['nodejs']['dir'], 'bin', 'node')
+
   template "#{new_resource.application.name}.upstart.conf" do
     path "/etc/init/#{new_resource.application.name}_nodejs.conf"
     source new_resource.template ? new_resource.template : 'nodejs.upstart.conf.erb'
@@ -80,7 +82,7 @@ action :before_restart do
     variables(
       :user => new_resource.owner,
       :group => new_resource.group,
-      :node_dir => node['nodejs']['dir'],
+      :node_binary => node_binary,
       :app_dir => new_resource.release_path,
       :entry => new_resource.entry_point,
       :environment => new_resource.environment

--- a/providers/nodejs.rb
+++ b/providers/nodejs.rb
@@ -28,10 +28,12 @@ action :before_compile do
     include_recipe 'nodejs::npm'
   end
 
+  app_name = new_resource.application.name
+
   unless new_resource.restart_command
     new_resource.restart_command do
 
-      service "#{new_resource.application.name}_nodejs" do
+      service "#{app_name}_nodejs" do
         provider Chef::Provider::Service::Upstart
         supports :restart => true, :start => true, :stop => true
         action [:enable, :restart]

--- a/providers/nodejs.rb
+++ b/providers/nodejs.rb
@@ -28,12 +28,16 @@ action :before_compile do
     include_recipe 'nodejs::npm'
   end
 
-  app_name = new_resource.application.name
+  service_name = if new_resource.service_name.nil?
+                   new_resource.application.name
+                 else
+                   new_resource.service_name
+                 end
 
   unless new_resource.restart_command
     new_resource.restart_command do
 
-      service "#{app_name}_nodejs" do
+      service "#{service_name}_nodejs" do
         provider Chef::Provider::Service::Upstart
         supports :restart => true, :start => true, :stop => true
         action [:enable, :restart]
@@ -74,8 +78,14 @@ action :before_restart do
 
   node_binary = ::File.join(node['nodejs']['dir'], 'bin', 'node')
 
-  template "#{new_resource.application.name}.upstart.conf" do
-    path "/etc/init/#{new_resource.application.name}_nodejs.conf"
+  service_name = if new_resource.service_name.nil?
+                   new_resource.application.name
+                 else
+                   new_resource.service_name
+                 end
+
+  template "#{service_name}.upstart.conf" do
+    path "/etc/init/#{service_name}_nodejs.conf"
     source new_resource.template ? new_resource.template : 'nodejs.upstart.conf.erb'
     cookbook new_resource.template ? new_resource.cookbook_name.to_s : 'application_nodejs'
     owner 'root'

--- a/providers/nodejs.rb
+++ b/providers/nodejs.rb
@@ -95,7 +95,7 @@ action :before_restart do
       :user => new_resource.owner,
       :group => new_resource.group,
       :node_binary => node_binary,
-      :app_dir => new_resource.release_path,
+      :app_dir => ::File.join(new_resource.path, 'current'),
       :entry => new_resource.entry_point,
       :environment => new_resource.environment
     )

--- a/resources/nodejs.rb
+++ b/resources/nodejs.rb
@@ -23,3 +23,4 @@ include ApplicationCookbook::ResourceBase
 attribute :npm, :kind_of => [NilClass, TrueClass, FalseClass], :default => true
 attribute :template, :kind_of => [String, NilClass], :default => nil
 attribute :entry_point, :kind_of => String, :default => 'app.js'
+attribute :service_name, :kind_of => [String, NilClass], :default => nil

--- a/templates/default/nodejs.upstart.conf.erb
+++ b/templates/default/nodejs.upstart.conf.erb
@@ -16,4 +16,4 @@ setuid <%= @user %>
 setgid <%= @group %>
 <% end -%>
 chdir <%= @app_dir %>
-exec <%= @node_dir %>/bin/node <%= @entry %>
+exec <%= @node_binary %> <%= @entry %>


### PR DESCRIPTION
First of all, thanks for making this available.
I was having some trouble using this cookbook with the release of Ubuntu 14.04, so I made some changes.

This works fine with both edge/master versions of application and nodejs cookbooks.

I'm not quite sure how support for node is on other distros, but the latest Ubuntu releases have kept pretty up2date, and now the nodejs cookbook has changed their policy to use the packages from the ppa.

The only reason the forced attribute now has more to do with the npm install than with the presence of node itself. I'd argue that maybe a better solution to including the nodejs::npm recipe would be to check for the executable on the system, because that recipe is a bit nuts :) One can only avoid this by making sure both ```node['nodejs']['dir']``` and ```node['nodejs']['npm']``` version are set right.

Anyway, with the changes, we can now have recipes that look like, for people like me, who have multiple daemons in the same repo:

```ruby
application 'ologger' do
  path node['infosan']['ologger']['dir']
  owner node['infosan']['user']
  group node['infosan']['user']
  repository node['infosan']['ologger']['repo']
  deploy_key File.join(node['infosan']['home'], '.ssh', 'bitbucket')
  action :deploy

  nodejs do
    entry_point 'bin/collectord'
    service_name 'collector'
  end

  nodejs do
    entry_point 'bin/commandsd'
    service_name 'commands'
  end
end
```
