### PR TITLE
metadata: name attribute is required in berkshelf >= 3.0.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "application_nodejs"
 maintainer       "Conrad Kramer"
 maintainer_email "conrad@kramerapps.com"
 license          "Apache 2.0"


### PR DESCRIPTION
This small change enables the use of your `application_nodejs` cookbook with the current release of Berkshelf, fixing an error such as this:

    Ridley::Errors::MissingNameAttribute The metadata at '/tmp/d20140507-1685-n7imbz' does not contain a 'name' attribute. While Chef does not strictly enforce this requirement, Ridley cannot continue without a valid metadata 'name' entry.
