### PR TITLE
Add Backwards Compatibility to Upstart

### DIFF
--- a/templates/centos-6/nodejs.upstart.conf.erb
+++ b/templates/centos-6/nodejs.upstart.conf.erb
@@ -1,0 +1,14 @@
+#!upstart
+description "Node.js Application Server"
+
+start on (local-filesystems and net-device-up IFACE!=lo)
+stop on [!12345]
+
+<% if @user.nil? && @group.nil? %>
+exec "<% @environment.each do |key, value| -%><%= key %>=<%= value %> <% end -%><%= @node_dir %>/bin/node <%= @entry %>"
+<% else -%>
+exec su -c "<% @environment.each do |key, value| -%><%= key %>=<%= value %> <% end -%><%= @node_dir %>/bin/node <%= @entry %>" -s /bin/bash <%= @user %>
+<% end -%>
+
+chdir <%= @app_dir %>
+


### PR DESCRIPTION
Not a complete solution, by any means, as I've only added a custom template for `centos-6` nodes, but it would be easy enough to add templates for other distros that use older versions of Upstart.