### PR TITLE
Added "name" Attribute to metadata.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "application_nodejs"
 maintainer       "Conrad Kramer"
 maintainer_email "conrad@kramerapps.com"
 license          "Apache 2.0"


### PR DESCRIPTION
Without it, a Vagrant run using Berkshelf fails, e.g.:

```
stderr: The following error occurred while reading the cookbook `application_nodejs':
Ridley::Errors::MissingNameAttribute: The metadata at '/tmp/d20150216-17470-1laf605' does not contain a 'name' attribute. While Chef does not strictly enforce this requirement, Ridley cannot continue without a valid metadata 'name' entry.
```