### PR TITLE
Install method fix via recipe switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This requirement can be worked around by specifying a custom template.
 The following Opscode cookbooks are dependencies:
 
 * [application](https://github.com/opscode-cookbooks/application)
-* [nodejs](https://github.com/mdxp/nodejs-cookbook)
+* [nodejs](https://github.com/redguide/nodejs)
 
 ## Resources/Providers
 
@@ -38,7 +38,7 @@ application "hello-world" do
   packages ["git"]
 
   repository "git://github.com/visionmedia/express.git"
-  
+
   nodejs do
     entry_point "examples/hello-world"
   end

--- a/providers/nodejs.rb
+++ b/providers/nodejs.rb
@@ -22,7 +22,7 @@ include Chef::DSL::IncludeRecipe
 
 action :before_compile do
 
-  include_recipe 'nodejs::install_from_source'
+  include_recipe 'nodejs::install' # let the nodejs cookbook do the install based on attribute precedence
 
   if new_resource.npm
     include_recipe 'nodejs::npm'


### PR DESCRIPTION
Let attribute precedence and user preference guide the nodejs install
method.

Also necessary as latest nodejs cookbook deprecated the
install_from_source recipe.