### PR TITLE
Add template for rhel6

### DIFF
--- a/templates/redhat-6/nodejs.upstart.conf.erb
+++ b/templates/redhat-6/nodejs.upstart.conf.erb
@@ -1,0 +1,14 @@
+#!upstart
+description "Node.js Application Server"
+
+start on (local-filesystems and net-device-up IFACE!=lo)
+stop on [!12345]
+
+<% if @user.nil? && @group.nil? %>
+exec "<% @environment.each do |key, value| -%><%= key %>=<%= value %> <% end -%><%= @node_binary %> <%= @entry %>"
+<% else -%>
+exec su -c "<% @environment.each do |key, value| -%><%= key %>=<%= value %> <% end -%><%= @node_binary %> <%= @entry %>" -s /bin/bash <%= @user %>
+<% end -%>
+
+chdir <%= @app_dir %>
+


### PR DESCRIPTION
This PR adds a template that supports the redhat-6 platform. It is very similar to the centos-6 one except I changed it to use the node_binary location like in the default template.